### PR TITLE
Added ThreadedQRandomX limiting change of MXCSR flags + Unit Tests to check the flag

### DIFF
--- a/src/pow/powhelper.cpp
+++ b/src/pow/powhelper.cpp
@@ -22,7 +22,6 @@
   */
 
 #include "powhelper.h"
-#include "qrandomx/qrandomx.h"
 #include "qrandomx/qrandomxpool.h"
 #include "misc/bignum.h"
 

--- a/src/qrandomx/qrandomxpool.cpp
+++ b/src/qrandomx/qrandomxpool.cpp
@@ -26,7 +26,8 @@
 QRandomXPool::ReturnToPoolDeleter::ReturnToPoolDeleter(std::weak_ptr<QRandomXPool> ptrToOwnerPool)
         : _ptrToOwnerPool(ptrToOwnerPool) { }
 
-void QRandomXPool::ReturnToPoolDeleter::operator()(QRandomX* ptrToReleasedObject)
+//void QRandomXPool::ReturnToPoolDeleter::operator()(QRandomX* ptrToReleasedObject)
+void QRandomXPool::ReturnToPoolDeleter::operator()(ThreadedQRandomX* ptrToReleasedObject)
 {
   if (auto pool = _ptrToOwnerPool.lock())
   {

--- a/src/qrandomx/qrandomxpool.cpp
+++ b/src/qrandomx/qrandomxpool.cpp
@@ -26,7 +26,6 @@
 QRandomXPool::ReturnToPoolDeleter::ReturnToPoolDeleter(std::weak_ptr<QRandomXPool> ptrToOwnerPool)
         : _ptrToOwnerPool(ptrToOwnerPool) { }
 
-//void QRandomXPool::ReturnToPoolDeleter::operator()(QRandomX* ptrToReleasedObject)
 void QRandomXPool::ReturnToPoolDeleter::operator()(ThreadedQRandomX* ptrToReleasedObject)
 {
   if (auto pool = _ptrToOwnerPool.lock())
@@ -70,7 +69,7 @@ QRandomXPool::uniqueQRandomXPtr QRandomXPool::acquire()
   std::unique_lock<std::mutex> lock(_mutex);
   if (_poolContainer.empty())
   {
-    // no QRandomX intances availabe in the pool so use the factory to
+    // no QRandomX instances available in the pool so use the factory to
     // create and return a new one
     return uniqueQRandomXPtr{_factory(), ReturnToPoolDeleter(shared_from_this())};
   }

--- a/src/qrandomx/qrandomxpool.h
+++ b/src/qrandomx/qrandomxpool.h
@@ -24,7 +24,8 @@
 #ifndef QRANDOMX_QRANDOMXPOOL_H
 #define QRANDOMX_QRANDOMXPOOL_H
 
-#include "qrandomx.h"
+//#include "qrandomx.h"
+#include "threadedqrandomx.h"
 #include <mutex>
 #include <stack>
 #include <memory>
@@ -39,9 +40,11 @@ class QRandomXPool : public std::enable_shared_from_this<QRandomXPool>
 public:
 
   // a factory function to create new QRandomX objects
-  using QRandomXFactory = std::function<QRandomX*()>;
+//  using QRandomXFactory = std::function<QRandomX*()>;
+  using QRandomXFactory = std::function<ThreadedQRandomX*()>;
 
-  QRandomXPool(QRandomXFactory factory = [](){ return new QRandomX(); });
+//  QRandomXPool(QRandomXFactory factory = [](){ return new QRandomX(); });
+  QRandomXPool(QRandomXFactory factory = [](){ return new ThreadedQRandomX(); });
 
   virtual ~QRandomXPool();
 
@@ -51,14 +54,16 @@ public:
   {
   public:
       explicit ReturnToPoolDeleter(std::weak_ptr<QRandomXPool> ptrToOwnerPool);
-      void operator()(QRandomX* ptrToReleasedObject);
+//      void operator()(QRandomX* ptrToReleasedObject);
+      void operator()(ThreadedQRandomX* ptrToReleasedObject);
       void detachFromPool();
   private:
       std::weak_ptr<QRandomXPool> _ptrToOwnerPool;
   };
 
   // a std::unique_ptr with a custome deleter that the client will use
-  using uniqueQRandomXPtr = std::unique_ptr<QRandomX, ReturnToPoolDeleter>;
+//  using uniqueQRandomXPtr = std::unique_ptr<QRandomX, ReturnToPoolDeleter>;
+  using uniqueQRandomXPtr = std::unique_ptr<ThreadedQRandomX, ReturnToPoolDeleter>;
 
   // obtain an unused QRandomX instance from the pool or
   // create a new one if there are none available

--- a/src/qrandomx/qrandomxpool.h
+++ b/src/qrandomx/qrandomxpool.h
@@ -24,7 +24,6 @@
 #ifndef QRANDOMX_QRANDOMXPOOL_H
 #define QRANDOMX_QRANDOMXPOOL_H
 
-//#include "qrandomx.h"
 #include "threadedqrandomx.h"
 #include <mutex>
 #include <stack>
@@ -40,10 +39,8 @@ class QRandomXPool : public std::enable_shared_from_this<QRandomXPool>
 public:
 
   // a factory function to create new QRandomX objects
-//  using QRandomXFactory = std::function<QRandomX*()>;
   using QRandomXFactory = std::function<ThreadedQRandomX*()>;
 
-//  QRandomXPool(QRandomXFactory factory = [](){ return new QRandomX(); });
   QRandomXPool(QRandomXFactory factory = [](){ return new ThreadedQRandomX(); });
 
   virtual ~QRandomXPool();
@@ -54,7 +51,6 @@ public:
   {
   public:
       explicit ReturnToPoolDeleter(std::weak_ptr<QRandomXPool> ptrToOwnerPool);
-//      void operator()(QRandomX* ptrToReleasedObject);
       void operator()(ThreadedQRandomX* ptrToReleasedObject);
       void detachFromPool();
   private:
@@ -62,7 +58,6 @@ public:
   };
 
   // a std::unique_ptr with a custome deleter that the client will use
-//  using uniqueQRandomXPtr = std::unique_ptr<QRandomX, ReturnToPoolDeleter>;
   using uniqueQRandomXPtr = std::unique_ptr<ThreadedQRandomX, ReturnToPoolDeleter>;
 
   // obtain an unused QRandomX instance from the pool or

--- a/src/qrandomx/qrxminer.cpp
+++ b/src/qrandomx/qrxminer.cpp
@@ -29,7 +29,6 @@
 #include <iomanip>
 #include <chrono>
 
-
 #ifndef _WIN32
 #include <netinet/in.h>
 #include <cstring>

--- a/src/qrandomx/qrxminer.cpp
+++ b/src/qrandomx/qrxminer.cpp
@@ -29,6 +29,7 @@
 #include <iomanip>
 #include <chrono>
 
+
 #ifndef _WIN32
 #include <netinet/in.h>
 #include <cstring>

--- a/src/qrandomx/threadedqrandomx.cpp
+++ b/src/qrandomx/threadedqrandomx.cpp
@@ -1,0 +1,110 @@
+/*
+  * This program is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 3 of the License, or
+  * any later version.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  *
+  * Additional permission under GNU GPL version 3 section 7
+  *
+  * If you modify this Program, or any covered work, by linking or combining
+  * it with OpenSSL (or a modified version of that library), containing parts
+  * covered by the terms of OpenSSL License and SSLeay License, the licensors
+  * of this Program grant you additional permission to convey the resulting work.
+  *
+  */
+#include <iostream>
+#include "threadedqrandomx.h"
+#include "qrandomx/qrandomx.h"
+
+ThreadedQRandomX::ThreadedQRandomX() {
+  _eventThread = std::make_unique<std::thread>([&]() { _threadedQRandomXProxy(); });
+}
+
+ThreadedQRandomX::~ThreadedQRandomX() {
+  {
+    std::lock_guard<std::mutex> queue_lock(_eventQueue_mutex);
+    _stop_eventThread = true;
+    _eventReleased.notify_one();
+  }
+  _eventThread->join();
+}
+
+void ThreadedQRandomX::_submitWork(std::shared_ptr<QRandomXParams>& qrxParams) {
+  std::lock_guard<std::mutex> lock_queue(_eventQueue_mutex);
+  _eventQueue.push_back(qrxParams);
+  _eventReleased.notify_one();
+}
+
+void ThreadedQRandomX::freeVM() {
+
+}
+
+uint64_t ThreadedQRandomX::getSeedHeight(const uint64_t blockNumber) {
+  std::shared_ptr<QRandomXParams> qrxParams = std::make_shared<QRandomXParams>(blockNumber);
+
+  _submitWork(qrxParams);
+
+  std::unique_lock<std::mutex> outputQLock(qrxParams->outputQueueMutex);
+  qrxParams->outputReady.wait(outputQLock);
+  auto data = qrxParams->output.front().heightOutput;
+  return data;
+}
+
+std::vector<uint8_t> ThreadedQRandomX::hash(const uint64_t mainHeight,
+        const uint64_t seedHeight, const std::vector<uint8_t>& seedHash,
+        const std::vector<uint8_t>& input, int miners) {
+
+  std::shared_ptr<QRandomXParams> qrxParams = std::make_shared<QRandomXParams>(mainHeight,
+          seedHeight, seedHash, input, miners);
+  _submitWork(qrxParams);
+
+  // Check outputReady
+  std::unique_lock<std::mutex> outputQLock(qrxParams->outputQueueMutex);
+  qrxParams->outputReady.wait(outputQLock);
+
+  return qrxParams->output.front().hashOutput;
+}
+
+void ThreadedQRandomX::_threadedQRandomXProxy() {
+  std::unique_ptr<QRandomX> qrx(new QRandomX);
+  while (!_stop_eventThread) {
+    std::unique_lock<std::mutex> queue_lock(_eventQueue_mutex);
+    _eventReleased.wait(queue_lock,
+                        [=] { return !_eventQueue.empty() || _stop_eventThread; });
+
+    if (!_eventQueue.empty()) {
+      auto event = _eventQueue.front();
+      _eventQueue.pop_front();
+      queue_lock.unlock();
+      // Process Request
+      QRandomXProxyResult qrxResult;
+      switch(event->funcType) {
+        case 0:
+          qrxResult.hashOutput = qrx->hash(event->mainHeight, event->seedHeight,
+                  event->seedHash, event->input, event->miners);
+          break;
+        case 1:
+          qrxResult.heightOutput = qrx->getSeedHeight(event->mainHeight);
+          break;
+        case 2:
+          qrx->freeVM();
+          break;
+      }
+      //TODO: Notify output is ready
+      std::lock_guard<std::mutex> lock_queue(event->outputQueueMutex);
+      event->output.push_back(qrxResult);
+      event->outputReady.notify_one();
+    }
+    else {
+      queue_lock.unlock();
+    }
+  }
+}

--- a/src/qrandomx/threadedqrandomx.h
+++ b/src/qrandomx/threadedqrandomx.h
@@ -1,0 +1,98 @@
+/*
+  * This program is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 3 of the License, or
+  * any later version.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  *
+  * Additional permission under GNU GPL version 3 section 7
+  *
+  * If you modify this Program, or any covered work, by linking or combining
+  * it with OpenSSL (or a modified version of that library), containing parts
+  * covered by the terms of OpenSSL License and SSLeay License, the licensors
+  * of this Program grant you additional permission to convey the resulting work.
+  *
+  */
+
+#ifndef QRANDOMX_THREADEDQRANDOMX_H
+#define QRANDOMX_THREADEDQRANDOMX_H
+
+#include <atomic>
+#include <thread>
+#include <mutex>
+#include <future>
+#include <deque>
+#include <vector>
+
+struct QRandomXProxyResult {
+    std::vector<uint8_t> hashOutput;
+    uint64_t heightOutput;
+};
+
+class QRandomXParams {
+public:
+    QRandomXParams(const uint64_t& mainHeight) {
+      this->mainHeight = mainHeight;
+      this->funcType = 1;
+    }
+
+    QRandomXParams(const uint64_t& mainHeight,
+                   const uint64_t& seedHeight,
+                   const std::vector<uint8_t>& seedHash,
+                   const std::vector<uint8_t>& input,
+                   int& miners) {
+      this->mainHeight = mainHeight;
+      this->seedHeight = seedHeight;
+      this->seedHash = seedHash;
+      this->input = input;
+      this->miners = miners;
+      this->funcType = 0;
+    }
+
+    uint64_t mainHeight;
+    uint64_t seedHeight;
+    std::vector<uint8_t> seedHash;
+    std::vector<uint8_t> input;
+    int miners;
+
+    std::deque<QRandomXProxyResult> output;
+    std::mutex outputQueueMutex;
+    std::condition_variable outputReady;
+
+    int funcType;
+};
+
+class ThreadedQRandomX {
+public:
+    std::atomic_bool _stop_eventThread{false};
+    std::unique_ptr<std::thread> _eventThread;
+
+    std::deque<std::shared_ptr<QRandomXParams>> _eventQueue;
+    std::mutex _eventQueue_mutex;
+    std::condition_variable _eventReleased;
+
+    ThreadedQRandomX();
+    virtual ~ThreadedQRandomX();
+
+    void _submitWork(std::shared_ptr<QRandomXParams>& qrxParams);
+    void _threadedQRandomXProxy();
+
+    void freeVM();
+
+    std::string lastError() { return std::string(""); };
+
+    uint64_t getSeedHeight(const uint64_t blockNumber);
+
+    std::vector<uint8_t> hash(const uint64_t mainHeight,
+                              const uint64_t seedHeight, const std::vector<uint8_t>& seedHash,
+                              const std::vector<uint8_t>& input, int miners);
+};
+
+#endif //QRANDOMX_THREADEDQRANDOMX_H

--- a/tests/cpp/powhelper.cpp
+++ b/tests/cpp/powhelper.cpp
@@ -21,10 +21,14 @@
   *
   */
 #include <iostream>
+#include <xmmintrin.h>
 #include <qrandomx/qrxminer.h>
 #include <pow/powhelper.h>
 #include <misc/bignum.h>
 #include "gtest/gtest.h"
+
+#define MINEXPECTEDMXCSR 8064
+#define MAXEXPECTEDMXCSR 8127
 
 namespace {
   TEST(PoWHelper, TargetCalculationDifficultyZero) {
@@ -35,6 +39,8 @@ namespace {
     auto target = ph.getTarget(zeros);
 
     EXPECT_EQ(zeros, target);
+    ASSERT_GE(_mm_getcsr(), MINEXPECTEDMXCSR);
+    ASSERT_LE(_mm_getcsr(), MAXEXPECTEDMXCSR);
   }
 
   TEST(PoWHelper, TargetCalculationDifficultyOne) {
@@ -63,6 +69,8 @@ namespace {
     };
 
     EXPECT_EQ(expected_target, target);
+    ASSERT_GE(_mm_getcsr(), MINEXPECTEDMXCSR);
+    ASSERT_LE(_mm_getcsr(), MAXEXPECTEDMXCSR);
   }
 
   TEST(PoWHelper, TargetCalculationDifficultyTwo) {
@@ -91,6 +99,8 @@ namespace {
     };
 
     EXPECT_EQ(expected_target, target);
+    ASSERT_GE(_mm_getcsr(), MINEXPECTEDMXCSR);
+    ASSERT_LE(_mm_getcsr(), MAXEXPECTEDMXCSR);
   }
 
   TEST(PoWHelper, TargetCalculationDifficultyLow) {
@@ -118,6 +128,8 @@ namespace {
     };
 
     EXPECT_EQ(expected_target, target);
+    ASSERT_GE(_mm_getcsr(), MINEXPECTEDMXCSR);
+    ASSERT_LE(_mm_getcsr(), MAXEXPECTEDMXCSR);
   }
 
   TEST(PoWHelper, TargetCalculationDifficulty2) {
@@ -136,6 +148,8 @@ namespace {
     std::cout << printByteVector(target) << std::endl;
 
     EXPECT_EQ(expected_target, target);
+    ASSERT_GE(_mm_getcsr(), MINEXPECTEDMXCSR);
+    ASSERT_LE(_mm_getcsr(), MAXEXPECTEDMXCSR);
   }
 
   TEST(PoWHelper, DifficultyOne) {
@@ -163,14 +177,19 @@ namespace {
 
     answer = ph.getDifficulty(90, toByteVector(1000000) );
     EXPECT_EQ(951172, fromByteVector(answer));
+
+    ASSERT_GE(_mm_getcsr(), MINEXPECTEDMXCSR);
+    ASSERT_LE(_mm_getcsr(), MAXEXPECTEDMXCSR);
   }
 
   TEST(PoWHelper, DifficultyExtreme) {
     PoWHelper ph;
 
     std::vector<uint8_t> answer = ph.getDifficulty(187, toByteVector(10727) );
-
     EXPECT_EQ(8517, fromByteVector(answer));
+
+    ASSERT_GE(_mm_getcsr(), MINEXPECTEDMXCSR);
+    ASSERT_LE(_mm_getcsr(), MAXEXPECTEDMXCSR);
   }
 
   TEST(PoWHelper, DifficultyFlatQuantization) {
@@ -188,6 +207,9 @@ namespace {
 
     answer = ph.getDifficulty(70, toByteVector(5) );
     EXPECT_EQ(4, fromByteVector(answer));
+
+    ASSERT_GE(_mm_getcsr(), MINEXPECTEDMXCSR);
+    ASSERT_LE(_mm_getcsr(), MAXEXPECTEDMXCSR);
   }
 
   TEST(PoWHelper, DifficultyTarget) {
@@ -217,5 +239,8 @@ namespace {
 
     difficulty = ph.getDifficulty(90, toByteVector(1000000) );
     EXPECT_EQ(951172, fromByteVector(difficulty));
+
+    ASSERT_GE(_mm_getcsr(), MINEXPECTEDMXCSR);
+    ASSERT_LE(_mm_getcsr(), MAXEXPECTEDMXCSR);
   }
 }

--- a/tests/cpp/qrandomx.cpp
+++ b/tests/cpp/qrandomx.cpp
@@ -21,16 +21,30 @@
   *
   */
 #include <iostream>
+#include <xmmintrin.h>
 #include <qrandomx/qrandomx.h>
 #include <misc/bignum.h>
 #include "gtest/gtest.h"
 
+#define MINEXPECTEDMXCSR 8064
+
 namespace {
-  TEST(QRandomX, Init) {
+  class QRandomXTest : public ::testing::Test {
+  protected:
+      void SetUp() override {
+        _mm_setcsr(8064);  // Resetting MXCSR value to default, as its changed by RandomX VM
+      }
+
+      void TearDown() override {
+        _mm_setcsr(8064);  // Resetting MXCSR value to default, as its changed by RandomX VM
+      }
+  };
+
+  TEST_F(QRandomXTest, Init) {
     QRandomX qrx;
   }
 
-  TEST(QRandomX, RunSingleHash) {
+  TEST_F(QRandomXTest, RunSingleHash) {
     QRandomX qrx;
 
     uint64_t main_height = 10;
@@ -70,7 +84,7 @@ namespace {
     EXPECT_EQ(output_expected, output);
   }
 
-  TEST(QRandomX, RunSingleHashBigBlob) {
+  TEST_F(QRandomXTest, RunSingleHashBigBlob) {
     QRandomX qrx;
 
     uint64_t main_height = 9865;

--- a/tests/cpp/qrandomxpool.cpp
+++ b/tests/cpp/qrandomxpool.cpp
@@ -21,15 +21,18 @@
   *
   */
 #include <iostream>
+#include <xmmintrin.h>
 #include <qrandomx/qrandomxpool.h>
 #include "gtest/gtest.h"
 
-namespace {
+#define MINEXPECTEDMXCSR 8064
+#define MAXEXPECTEDMXCSR 8127
 
-  class QRandomXWithRefCount : public QRandomX
+namespace {
+  class QRandomXWithRefCount : public ThreadedQRandomX
   {
   public:
-      QRandomXWithRefCount() : QRandomX() { ++_instances; }
+      QRandomXWithRefCount() : ThreadedQRandomX() { ++_instances; }
       virtual ~QRandomXWithRefCount() { --_instances; }
       static size_t _instances;
   };
@@ -76,6 +79,8 @@ namespace {
     auto output = qrx->hash(main_height, seed_height, seed_hash, input, miners);
 
     EXPECT_EQ(output_expected, output);
+    ASSERT_GE(_mm_getcsr(), MINEXPECTEDMXCSR);
+    ASSERT_LE(_mm_getcsr(), MAXEXPECTEDMXCSR);
   }
 
   TEST(QRandomXPool, Init) {
@@ -83,6 +88,8 @@ namespace {
     EXPECT_TRUE(pool->empty());
     EXPECT_EQ(pool->size(), 0);
     EXPECT_EQ(QRandomXWithRefCount::_instances, 0);
+    ASSERT_GE(_mm_getcsr(), MINEXPECTEDMXCSR);
+    ASSERT_LE(_mm_getcsr(), MAXEXPECTEDMXCSR);
   }
 
   TEST(QRandomXPool, Empty) {
@@ -95,6 +102,8 @@ namespace {
     qrx.reset();
     EXPECT_FALSE(pool->empty());
     EXPECT_EQ(QRandomXWithRefCount::_instances, 1);
+    ASSERT_GE(_mm_getcsr(), MINEXPECTEDMXCSR);
+    ASSERT_LE(_mm_getcsr(), MAXEXPECTEDMXCSR);
   }
 
   TEST(QRandomXPool, AcquireHashReleaseCycle) {
@@ -122,6 +131,8 @@ namespace {
 
     pool.reset();
     EXPECT_EQ(QRandomXWithRefCount::_instances, 0);
+    ASSERT_GE(_mm_getcsr(), MINEXPECTEDMXCSR);
+    ASSERT_LE(_mm_getcsr(), MAXEXPECTEDMXCSR);
   }
 
   TEST(QRandomXPool, AcquireHashReleaseFour) {
@@ -148,6 +159,8 @@ namespace {
 
     pool.reset();
     EXPECT_EQ(QRandomXWithRefCount::_instances, 0);
+    ASSERT_GE(_mm_getcsr(), MINEXPECTEDMXCSR);
+    ASSERT_LE(_mm_getcsr(), MAXEXPECTEDMXCSR);
   }
 
   TEST(QRandomXPool, AcquireAndDeletePool) {
@@ -166,6 +179,8 @@ namespace {
     qrx.reset();
 
     EXPECT_EQ(QRandomXWithRefCount::_instances, 0);
+    ASSERT_GE(_mm_getcsr(), MINEXPECTEDMXCSR);
+    ASSERT_LE(_mm_getcsr(), MAXEXPECTEDMXCSR);
   }
 
 }

--- a/tests/cpp/qrxminer.cpp
+++ b/tests/cpp/qrxminer.cpp
@@ -21,11 +21,15 @@
   *
   */
 #include <iostream>
+#include <xmmintrin.h>
 #include <qrandomx/qrxminer.h>
 #include <misc/bignum.h>
 #include <pow/powhelper.h>
-#include <qrandomx/qrandomx.h>
+#include <qrandomx/threadedqrandomx.h>
 #include "gtest/gtest.h"
+
+#define MINEXPECTEDMXCSR 8064
+#define MAXEXPECTEDMXCSR 8127
 
 namespace {
   TEST(QRXMiner, PassesTarget) {
@@ -56,12 +60,14 @@ namespace {
       std::cout << printByteVector2(over_1) << std::endl;
       ASSERT_FALSE(PoWHelper::passesTarget(over_1, target));
     }
+    ASSERT_GE(_mm_getcsr(), MINEXPECTEDMXCSR);
+    ASSERT_LE(_mm_getcsr(), MAXEXPECTEDMXCSR);
   }
 
   TEST(QRXMiner, Run1Thread)
   {
     QRXMiner qm;
-    QRandomX qrx;
+    ThreadedQRandomX qrx;
 
     uint64_t main_height = 10;
     uint64_t seed_height = qrx.getSeedHeight(main_height);
@@ -128,12 +134,14 @@ namespace {
     std::cout << printByteVector2(qm.solutionHash()) << std::endl;
 
     EXPECT_EQ(expected_hash, qm.solutionHash());
+    ASSERT_GE(_mm_getcsr(), MINEXPECTEDMXCSR);
+    ASSERT_LE(_mm_getcsr(), MAXEXPECTEDMXCSR);
   }
 
   TEST(QRXMiner, RunThreads_KeepHashing)
   {
     QRXMiner qm;
-    QRandomX qrx;
+    ThreadedQRandomX qrx;
 
     uint64_t main_height = 10;
     uint64_t seed_height = qrx.getSeedHeight(main_height);
@@ -158,7 +166,7 @@ namespace {
 
     int hash_count = 0;
     while (!qm.solutionAvailable()) {
-      QRandomX qrx;
+      ThreadedQRandomX qrx;
 
       uint64_t main_height = 10;
       uint64_t seed_height = qrx.getSeedHeight(main_height);
@@ -190,12 +198,14 @@ namespace {
     // Due to multiple threads running, possible nonce solution may vary
     // following are the most triggered possible nonce values
     EXPECT_TRUE(qm.solutionNonce() == 7424 || qm.solutionNonce() == 7475);
+    ASSERT_GE(_mm_getcsr(), MINEXPECTEDMXCSR);
+    ASSERT_LE(_mm_getcsr(), MAXEXPECTEDMXCSR);
   }
 
   TEST(QRXMiner, Run1Thread_bigblob)
   {
     QRXMiner qm;
-    QRandomX qrx;
+    ThreadedQRandomX qrx;
 
     uint64_t main_height = 10;
     uint64_t seed_height = qrx.getSeedHeight(main_height);
@@ -223,12 +233,14 @@ namespace {
 
     ASSERT_TRUE(qm.solutionAvailable());
     EXPECT_EQ(2, qm.solutionNonce());
+    ASSERT_GE(_mm_getcsr(), MINEXPECTEDMXCSR);
+    ASSERT_LE(_mm_getcsr(), MAXEXPECTEDMXCSR);
   }
 
   TEST(QRXMiner, RunAndRestart)
   {
     QRXMiner qm;
-    QRandomX qrx;
+    ThreadedQRandomX qrx;
 
     uint64_t main_height = 10;
     uint64_t seed_height = qrx.getSeedHeight(main_height);
@@ -280,12 +292,14 @@ namespace {
     };
 
     EXPECT_EQ(expected_winner, qm.solutionInput());
+    ASSERT_GE(_mm_getcsr(), MINEXPECTEDMXCSR);
+    ASSERT_LE(_mm_getcsr(), MAXEXPECTEDMXCSR);
   }
 
   TEST(QRXMiner, MeasureHashRate)
   {
     QRXMiner qm;
-    QRandomX qrx;
+    ThreadedQRandomX qrx;
 
     uint64_t main_height = 10;
     uint64_t seed_height = qrx.getSeedHeight(main_height);
@@ -324,12 +338,14 @@ namespace {
     EXPECT_FALSE(qm.solutionAvailable());
     qm.cancel();
     ASSERT_FALSE(qm.isRunning());
+    ASSERT_GE(_mm_getcsr(), MINEXPECTEDMXCSR);
+    ASSERT_LE(_mm_getcsr(), MAXEXPECTEDMXCSR);
   }
 
   TEST(QRXMiner, RunAndCancel)
   {
     QRXMiner qm;
-    QRandomX qrx;
+    ThreadedQRandomX qrx;
 
     uint64_t main_height = 10;
     uint64_t seed_height = qrx.getSeedHeight(main_height);
@@ -367,12 +383,14 @@ namespace {
     ASSERT_FALSE(qm.isRunning());
 
     ASSERT_FALSE(qm.solutionAvailable());
+    ASSERT_GE(_mm_getcsr(), MINEXPECTEDMXCSR);
+    ASSERT_LE(_mm_getcsr(), MAXEXPECTEDMXCSR);
   }
 
   TEST(QRXMiner, RunCancelSafety)
   {
     QRXMiner qm;
-    QRandomX qrx;
+    ThreadedQRandomX qrx;
 
     uint64_t main_height = 10;
     uint64_t seed_height = qrx.getSeedHeight(main_height);
@@ -415,6 +433,8 @@ namespace {
     }
 
     ASSERT_FALSE(qm.isRunning());
+    ASSERT_GE(_mm_getcsr(), MINEXPECTEDMXCSR);
+    ASSERT_LE(_mm_getcsr(), MAXEXPECTEDMXCSR);
   }
 
 }

--- a/tests/cpp/qrxminer_complex.cpp
+++ b/tests/cpp/qrxminer_complex.cpp
@@ -21,11 +21,15 @@
   *
   */
 #include <iostream>
+#include <xmmintrin.h>
 #include <qrandomx/qrxminer.h>
 #include <misc/bignum.h>
 #include <pow/powhelper.h>
-#include <qrandomx/qrandomx.h>
+#include <qrandomx/threadedqrandomx.h>
 #include "gtest/gtest.h"
+
+#define MINEXPECTEDMXCSR 8064
+#define MAXEXPECTEDMXCSR 8127
 
 namespace {
   class CustomMiner: public QRXMiner
@@ -46,7 +50,7 @@ namespace {
 
   TEST(QRXMiner, CancelInEvent) {
     CustomMiner qrxm;
-    QRandomX qrx;
+    ThreadedQRandomX qrx;
 
     uint64_t main_height = 10;
     uint64_t seed_height = qrx.getSeedHeight(main_height);
@@ -86,5 +90,7 @@ namespace {
         std::this_thread::sleep_for(500ms);
         qrxm.cancel();
     }
+    ASSERT_GE(_mm_getcsr(), MINEXPECTEDMXCSR);
+    ASSERT_LE(_mm_getcsr(), MAXEXPECTEDMXCSR);
   }
 }


### PR DESCRIPTION
RandomX VM changes MXCSR flag which effects the precision. The effect of change of MXCSR flag is visible to the thread level. Some of its side effect has been observed in QRLLIB. 

With this new commit, ThreadedQRandomX will run Random VM on a separate thread, and which will not have any effect to the caller's thread MXCSR flag and will protect from any possibilities of side effect.