### PR TITLE
Pin dep to RandomX fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "deps/RandomX"]
 	path = deps/RandomX
-	url = https://github.com/tevador/RandomX
+	url = https://github.com/theQRL/RandomX


### PR DESCRIPTION
This pull request updates the source URL for the `RandomX` submodule to point to the `theQRL` GitHub repository instead of `tevador`. This ensures the submodule pulls from the intended fork or maintained version.